### PR TITLE
chore: update Node.js to v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,15 @@
         "websocket-polyfill": "^0.0.3"
       },
       "devDependencies": {
-        "@types/node": "^20.3.1",
+        "@types/node": "^22.0.0",
         "@vitejs/plugin-vue": "^4.1.0",
         "sass": "^1.62.0",
         "typescript": "^5.0.0",
         "vite": "^4.2.0",
         "vue-tsc": "^1.2.0"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@babel/parser": {
@@ -532,10 +535,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.4.tgz",
-      "integrity": "sha512-nU6d9MPY0NBUMiE/nXd2IIoC4OLvsLpwAjheoAeuzgvDZA1Cb10QYg+91AF6zQiKWRN5i1m07x6sMe0niBznoQ==",
-      "dev": true
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.3.4",
@@ -1562,6 +1569,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nostrglobal",
   "private": true,
   "version": "0.4.12",
+  "engines": {
+    "node": "22.x"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite --host",
@@ -26,7 +29,7 @@
     "websocket-polyfill": "^0.0.3"
   },
   "devDependencies": {
-    "@types/node": "^20.3.1",
+    "@types/node": "^22.0.0",
     "@vitejs/plugin-vue": "^4.1.0",
     "sass": "^1.62.0",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- require Node.js 22.x in engines
- bump @types/node to v22

## Testing
- `npm run build`
- `npm run check` *(fails: Object is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68aee3b44e1083318ca088a30f0e442d